### PR TITLE
Correct a typo in installation instructions

### DIFF
--- a/INSTALL.MD
+++ b/INSTALL.MD
@@ -42,7 +42,7 @@ Use [radiodan provisioning](https://github.com/radiodan/provision) to install no
 
 Once you've followed the setup instructions there:
 
-    sudo ./provision node ip-tables
+    sudo ./provision node iptables
 
 ## Install pHat DAC if using
 


### PR DESCRIPTION
The provision step is named `iptables`, not `ip-tables`.