### PR TITLE
A few tweaks to the installation instructions to make them easier to …

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,7 @@ Once you've followed the setup instructions there:
 Install the manager and example app:
 
     mkdir /opt/radiodan
+    cd /opt/radiodan 
     git clone https://github.com/andrewn/neue-radio rde
     cd rde/manager
     npm install --production

--- a/physical/package.json
+++ b/physical/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "board-io": "^3.0.5",
     "faye-websocket": "^0.11.0",
-    "johnny-five": "andrewn/johnny-five#button-pulldown-support"
+    "johnny-five": "^0.10.10"
   },
   "optionalDependencies": {
     "raspi-rotary-encoder": "andrewn/raspi-rotary-encoder",


### PR DESCRIPTION
…follow

 * Rename INSTALL.MD to INSTALL.md for consitency with other documentation and so link in README works
 * ensure that the user `cd`s into `/opt/radiodan` before checking out the repo
 * remove non-existent git branch reference in package.json of physical subdir.